### PR TITLE
Addition of Apptainer config, and GHCR manual workflows

### DIFF
--- a/.github/workflows/apptainer-build-deploy.yml
+++ b/.github/workflows/apptainer-build-deploy.yml
@@ -1,0 +1,31 @@
+name: Apptainer Build Deploy
+
+on: workflow_dispatch
+
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    container:
+        image: godlovedc/apptainer:latest
+        options: --privileged
+
+    name: Build Container
+    steps:
+
+      - name: Check out code for the container builds
+        uses: actions/checkout@v4
+
+      - name: Build Container
+        run: |
+           apptainer build pybeast.sif Apptainer.def
+
+      - name: Login and Deploy Container
+        if: (github.event_name != 'pull_request')
+        run: |
+           echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
+           apptainer push container.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}

--- a/.github/workflows/apptainer-build-deploy.yml
+++ b/.github/workflows/apptainer-build-deploy.yml
@@ -28,4 +28,4 @@ jobs:
         if: (github.event_name != 'pull_request')
         run: |
            echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
-           apptainer push container.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}
+           apptainer push pybeast.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -1,0 +1,77 @@
+name: Docker Build Deploy
+
+on: workflow_dispatch
+
+# Defines two custom environment variables for the workflow. These are used
+# for the Container registry domain, and a name for the Docker image that this
+# workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest
+# available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in
+    # this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container
+      # registry registry using the account and password that will publish the
+      # packages. Once published, the packages are scoped to the account
+      # defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses
+      # [docker/metadata-action](https://github.com/docker/metadata-action#about)
+      # to extract tags and labels that will be applied to the specified
+      # image. The `id` "meta" allows the output of this step to be referenced
+      # in a subsequent step. The `images` value provides the base name for
+      # the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the
+      # image, based on your repository's `Dockerfile`. If the build succeeds,
+      # it pushes the image to GitHub Packages.  It uses the `context`
+      # parameter to define the build's context as the set of files located in
+      # the specified path. For more information, see
+      # "[Usage](https://github.com/docker/build-push-action#usage)" in the
+      # README of the `docker/build-push-action` repository.  It uses the
+      # `tags` and `labels` parameters to tag and label the image with the
+      # output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an
+      # unforgeable statement about where and how it was built. It increases
+      # supply chain security for people who consume the image. For more
+      # information, see
+      # "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       # packages. Once published, the packages are scoped to the account
       # defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the
@@ -57,7 +57,7 @@ jobs:
       # output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Apptainer.def
+++ b/Apptainer.def
@@ -11,6 +11,7 @@ From: mambaorg/micromamba
     micromamba create -q -y -f environment.yml -p /opt/conda-env
     micromamba clean -aqy
     micromamba config set --system use_lockfiles false
+    ln -s /home/student/pybeast/pybeast /opt/pybeast
 
 %runscript
     micromamba run -p /opt/conda-env "$@"

--- a/Apptainer.def
+++ b/Apptainer.def
@@ -1,0 +1,16 @@
+Bootstrap: docker
+From: mambaorg/micromamba
+
+%files
+   . /home/student/pybeast
+   environment.yml
+
+%post
+    apt-get update
+    apt-get install -y libgl-dev libglu-dev
+    micromamba create -q -y -f environment.yml -p /opt/conda-env
+    micromamba clean -aqy
+    micromamba config set --system use_lockfiles false
+
+%runscript
+    micromamba run -p /opt/conda-env "$@"

--- a/README-apptainer.md
+++ b/README-apptainer.md
@@ -1,0 +1,40 @@
+## Installation
+
+Build the apptainer container from the `Apptainer.def` by running the
+following command from this directory:
+```
+apptainer build pybeast_latest.sif Apptainer.def
+```
+
+## Using prebuilt containers
+
+Both Docker and Apptainer images are prebuilt and hosted in GHCR.  You can
+pull these down instead of building from scratch:
+
+### Docker
+docker pull ghcr.io/jhodrien/pybeast:main
+
+### Apptainer
+apptainer pull oras://ghcr.io/jhodrien/pybeast:latest
+
+## Usage
+
+Once you have the container image, you can run commands directly in the
+container like this:
+```
+apptainer run pybeast_latest.sif python /opt/pybeast/beast.py
+```
+
+If you wanted an shell within the container:
+
+```
+apptainer run pybeast_latest.sif bash -i
+```
+
+## Notes
+
+If you're looking to develop code with Apptainer, it's in some ways much more
+convenient than doing it in Docker on Linux.  Apptainer by default maps the
+current directory and /tmp from the host system into the container, so you're
+free to store your work directly in a backed up home directory whilst working
+in the container, which remains read-only.


### PR DESCRIPTION
This contains an example definition file for Apptainer.  In addition, I've added a couple of github actions to build bother Apptainer and Docker containers and push them into GHCR, allowing users to then pull them back down again without having to build them from scratch.

There's an additional Readme file to provide some guidance on how it should be used from a user perspective.  You'd need to update the paths in that readme to reflect where you're hosting the git repo.

From an admin perspective, you just click the run workflow button in GitHub and it makes you your containers.  I don't know where the correct long term home is of pybeast.